### PR TITLE
fix warning

### DIFF
--- a/src/test/scala/controller/ControllersSpec.scala
+++ b/src/test/scala/controller/ControllersSpec.scala
@@ -1,7 +1,7 @@
 package controller
 
 import org.scalatest._
-import org.scalatest.mock.MockitoSugar
+import org.scalatest.mockito.MockitoSugar
 import skinny.ServletContext
 
 class ControllersSpec extends FlatSpec with Matchers with MockitoSugar {


### PR DESCRIPTION
```
[warn] /home/travis/build/atware/sharedocs/src/test/scala/controller/ControllersSpec.scala:7: type MockitoSugar in package mock is deprecated: Please use org.scalatest.mockito.MockitoSugar instead
[warn] class ControllersSpec extends FlatSpec with Matchers with MockitoSugar {
[warn]                                                           ^
```

https://travis-ci.org/atware/sharedocs/builds/192275748#L996