### PR TITLE
remove unnecessary TypeBinder instances

### DIFF
--- a/src/main/scala/model/typebinder/ArticleId.scala
+++ b/src/main/scala/model/typebinder/ArticleId.scala
@@ -7,6 +7,5 @@ case class ArticleId(value: Long) {
 }
 
 object ArticleId {
-  implicit val longTypeBinder: TypeBinder[ArticleId] = TypeBinder.long.map(ArticleId.apply)
   implicit val converter: Binders[ArticleId] = Binders.long.xmap(ArticleId.apply, _.value)
 }

--- a/src/main/scala/model/typebinder/CommentId.scala
+++ b/src/main/scala/model/typebinder/CommentId.scala
@@ -7,6 +7,5 @@ case class CommentId(value: Long) {
 }
 
 object CommentId {
-  implicit val longTypeBinder: TypeBinder[CommentId] = TypeBinder.long.map(CommentId.apply)
   implicit val converter: Binders[CommentId] = Binders.long.xmap(CommentId.apply, _.value)
 }

--- a/src/main/scala/model/typebinder/LikeId.scala
+++ b/src/main/scala/model/typebinder/LikeId.scala
@@ -7,6 +7,5 @@ case class LikeId(value: Long) {
 }
 
 object LikeId {
-  implicit val longTypeBinder: TypeBinder[LikeId] = TypeBinder.long.map(LikeId.apply)
   implicit val converter: Binders[LikeId] = Binders.long.xmap(LikeId.apply, _.value)
 }

--- a/src/main/scala/model/typebinder/TagId.scala
+++ b/src/main/scala/model/typebinder/TagId.scala
@@ -7,6 +7,5 @@ case class TagId(value: Long) {
 }
 
 object TagId {
-  implicit val longTypeBinder: TypeBinder[TagId] = TypeBinder.long.map(TagId.apply)
   implicit val converter: Binders[TagId] = Binders.long.xmap(TagId.apply, _.value)
 }

--- a/src/main/scala/model/typebinder/UserId.scala
+++ b/src/main/scala/model/typebinder/UserId.scala
@@ -7,6 +7,5 @@ case class UserId(value: Long) {
 }
 
 object UserId {
-  implicit val longTypeBinder: TypeBinder[UserId] = TypeBinder.long.map(UserId.apply)
   implicit val converter: Binders[UserId] = Binders.long.xmap(UserId.apply, _.value)
 }


### PR DESCRIPTION
scalikejdbc.Binders extends TypeBinder
https://github.com/scalikejdbc/scalikejdbc/blob/2.5.0/scalikejdbc-core/src/main/scala/scalikejdbc/Binders.scala#L10