### PR TITLE
Make docker-compose build/up faster

### DIFF
--- a/Dockerfile-app
+++ b/Dockerfile-app
@@ -1,10 +1,5 @@
-FROM ubuntu:latest
+FROM comutt/scala:2.12.1-8-jdk-jessie_sbt_npm
 
-RUN apt-get update
-RUN apt-get install -y scala
-RUN apt-get install -y curl
-RUN curl -sL https://deb.nodesource.com/setup_6.x | bash - && apt-get install -y nodejs
-RUN apt-get install -y  build-essential
 ADD . /opt/sharedocs/
 
 RUN touch /opt/sharedocs/sharedocsEnv


### PR DESCRIPTION
Current application container build takes a long time,
because building needs sbt and npm installing.

I've changed container base image to that includes sbt and npm,
so sbt and npm installing process is no more needed.

This improves container build time to about 2x faster.
