### PR TITLE
Fix read version.txt from classpath when not dev/test mode

### DIFF
--- a/src/main/scala/lib/AssetsHelper.scala
+++ b/src/main/scala/lib/AssetsHelper.scala
@@ -1,10 +1,19 @@
 package lib
 
+import skinny.SkinnyEnv
+
 import scala.io.Source
 
 object AssetsHelper {
-  val basePath = "src/main/webapp/assets/dist"
   val fileName = "version.txt"
 
-  val hash = Source.fromFile(s"${basePath}/${fileName}").mkString
+  val hash = {
+    if (SkinnyEnv.isDevelopment() || SkinnyEnv.isTest()) {
+      val basePath = "src/main/webapp/assets/dist"
+      Source.fromFile(s"${basePath}/${fileName}").mkString
+    } else {
+      val basePath = "assets/dist"
+      Source.fromInputStream(getClass.getClassLoader.getResourceAsStream(s"${basePath}/${fileName}")).mkString
+    }
+  }
 }


### PR DESCRIPTION
FileNotFoundException raise when run as standalone-jar because AssetsHelper try to read version.txt not classpath but file system.